### PR TITLE
Do not use camel-case for "ID" in clientID and adapterID

### DIFF
--- a/src/requests.rs
+++ b/src/requests.rs
@@ -39,10 +39,12 @@ fromstr_deser! {PathFormat}
 #[serde(rename_all = "camelCase")]
 pub struct InitializeArguments {
   /// The ID of the client using this adapter.
+  #[serde(rename = "clientID")]
   pub client_id: Option<String>,
   /// The human-readable name of the client using this adapter.
   pub client_name: Option<String>,
   /// The ID of the debug adapter.
+  #[serde(rename = "adapterID")]
   pub adapter_id: String,
   /// The ISO-639 locale of the client using this adapter, e.g. en-US or de-CH.
   pub locale: Option<String>,


### PR DESCRIPTION
Since this fix was never merged in the previous PR #2  i decided to go ahead an do it in my own fork.

I also have some other fixes coming, as I'm running into some issues while trying to get this to work with vscode :)