### PR TITLE
No newline breaks read and write

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -61,6 +61,7 @@ impl<W: Write> BasicClient<W> {
     write!(self.stream, "Content-Length: {}\r\n\r\n", resp_json.len())
       .map_err(ClientError::IoError)?;
     write!(self.stream, "{}\r\n", resp_json).map_err(ClientError::IoError)?;
+    self.stream.flush();
     Ok(())
   }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -61,7 +61,7 @@ impl<W: Write> BasicClient<W> {
     write!(self.stream, "Content-Length: {}\r\n\r\n", resp_json.len())
       .map_err(ClientError::IoError)?;
     write!(self.stream, "{}\r\n", resp_json).map_err(ClientError::IoError)?;
-    self.stream.flush();
+    self.stream.flush().map_err(ClientError::IoError)?;
     Ok(())
   }
 }


### PR DESCRIPTION
This change is needed (as far as i can tell), in order to use stdin and stdout as the interface for the debug adapter. I have tested with vscode and confirmed that this fixes the following errors:
- Input was not being read, as there is no newline seperator after the content.
- Output was not being flushed (on my machine), likely because there is no newline.

I decided the easiest thing to do was to combine the `Sep` and `Content` states, and read the content based on content-length, while keeping the rest of the loop based on `read_line`.

I'm still new to rust and what is considered best practices, so please point any mistakes or inefficiencies (especially error handling trips me up)