### PR TITLE
Add a base message that contains the sequence number and type

### DIFF
--- a/src/base_message.rs
+++ b/src/base_message.rs
@@ -1,0 +1,41 @@
+use serde::Serialize;
+
+use crate::{events::Event, responses::Response, reverse_requests::ReverseRequest};
+
+/// Represents the base protocol message, in which all other messages are wrapped.
+///
+/// Specification: [Response](https://microsoft.github.io/debug-adapter-protocol/specification)
+#[derive(Serialize, Debug)]
+pub struct BaseMessage {
+  /// Sequence number of the message. The `seq` for
+  /// the first message is 1, and for each message is incremented by 1.
+  pub seq: i64,
+  #[serde(flatten)]
+  pub message: Sendable,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "lowercase")]
+#[serde(tag = "type")]
+pub enum Sendable {
+  Response(Response),
+  Event(Event),
+  ReverseRequest(ReverseRequest),
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_message_serialize() {
+    let message = BaseMessage {
+      seq: 10,
+      message: Sendable::Event(Event::Initialized),
+    };
+    let json = serde_json::to_string(&message).unwrap();
+
+    let expected = "{\"seq\":10,\"type\":\"event\",\"event\":\"initialized\"}";
+    assert_eq!(json, expected);
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,14 @@
 #![doc = include_str!("../README.md")]
 pub mod adapter;
+pub mod base_message;
 pub mod client;
 pub mod errors;
 pub mod events;
 #[doc(hidden)]
 mod macros;
+pub mod prelude;
 pub mod requests;
 pub mod responses;
 pub mod reverse_requests;
 pub mod server;
 pub mod types;
-pub mod prelude;

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -10,7 +10,7 @@ use crate::{
   },
 };
 
-/// Represents a response messagte that is either a cancellation or a short error string.
+/// Represents a response message that is either a cancellation or a short error string.
 #[derive(Serialize, Debug)]
 pub enum ResponseMessage {
   /// Should be sent when the request was canceled
@@ -514,9 +514,6 @@ pub enum ResponseBody {
 
 /// Represents response to the client.
 ///
-/// Note that unlike the specification, this implementation does not define a ProtocolMessage base
-/// interface. Instead, the only common part (the sequence number) is repeated in the struct.
-///
 /// The command field (which is a string) is used as a tag in the ResponseBody enum, so users
 /// of this crate will control it by selecting the appropriate enum variant for the body.
 ///
@@ -528,6 +525,7 @@ pub enum ResponseBody {
 #[serde(rename_all = "camelCase")]
 pub struct Response {
   /// Sequence number of the corresponding request.
+  #[serde(rename = "request_seq")]
   pub request_seq: i64,
   /// Outcome of the request.
   /// If true, the request was successful and the `body` attribute may contain
@@ -694,7 +692,7 @@ impl Response {
       request_seq: 0,
       success: false,
       message: None,
-      body: Some(ResponseBody::Empty)
+      body: Some(ResponseBody::Empty),
     }
   }
 }


### PR DESCRIPTION
This PR adds the outer message wrapper with the sequence number and type.
I also modified the client to wrap all message in this base message and keep track the sequence number.

Any feedback is much appreciated 😀 