### PR TITLE
Add additional data fields to launch and attach requests

### DIFF
--- a/src/requests.rs
+++ b/src/requests.rs
@@ -145,6 +145,9 @@ pub struct LaunchRequestArguments {
   /// an encoding that is suitable for string (e.g. base85 or similar).
   #[serde(rename = "__restart")]
   pub restart_data: Option<Value>,
+  /// The request may include additional implementation specific attributes.
+  #[serde(flatten)]
+  pub additional_data: Option<Value>,
 }
 
 //// Arguments for an Attach request.
@@ -156,6 +159,10 @@ pub struct AttachRequestArguments {
   /// The client should leave the data intact.
   #[serde(rename = "__restart")]
   pub restart_data: Option<Value>,
+
+  /// The request may include additional implementation specific attributes.
+  #[serde(flatten)]
+  pub additional_data: Option<Value>,
 }
 
 //// Arguments for a BreakpointLocations request.


### PR DESCRIPTION
According to both the specification and my tests, both [launch](https://github.com/microsoft/debug-adapter-protocol/blob/gh-pages/specification.md#leftwards_arrow_with_hook-launch-request) and [attach](https://github.com/microsoft/debug-adapter-protocol/blob/gh-pages/specification.md#leftwards_arrow_with_hook-attach-request) allows the client to send arbitrary data as part of the arguments. 

While this extra data did not cause any panics or erros, this PR allows us to access this data using the `additional_data` field on the `AttachRequestArguments` and the `LaunchRequestArguments`.