### PR TITLE
Update to v1.62.x

### DIFF
--- a/dap/src/lib.rs
+++ b/dap/src/lib.rs
@@ -89,3 +89,5 @@ pub mod responses;
 pub mod reverse_requests;
 pub mod server;
 pub mod types;
+pub mod utils;
+pub use utils::get_spec_version;

--- a/dap/src/requests.rs
+++ b/dap/src/requests.rs
@@ -987,6 +987,7 @@ impl Request {
       success: true,
       message: None,
       body: Some(body), // to love
+      error: None,
     }
   }
 
@@ -1003,6 +1004,7 @@ impl Request {
       success: false,
       message: Some(ResponseMessage::Error(error.to_string())),
       body: None,
+      error: None,
     }
   }
 
@@ -1015,6 +1017,7 @@ impl Request {
       success: false,
       message: Some(ResponseMessage::Cancelled),
       body: None,
+      error: None,
     }
   }
 
@@ -1027,90 +1030,105 @@ impl Request {
         success: true,
         message: None,
         body: Some(ResponseBody::Attach),
+        error: None,
       }),
       Command::ConfigurationDone => Ok(Response {
         request_seq: self.seq,
         success: true,
         message: None,
         body: Some(ResponseBody::ConfigurationDone),
+        error: None,
       }),
       Command::Disconnect(_) => Ok(Response {
         request_seq: self.seq,
         success: true,
         message: None,
         body: Some(ResponseBody::Disconnect),
+        error: None,
       }),
       Command::Goto(_) => Ok(Response {
         request_seq: self.seq,
         success: true,
         message: None,
         body: Some(ResponseBody::Goto),
+        error: None,
       }),
       Command::Launch(_) => Ok(Response {
         request_seq: self.seq,
         success: true,
         message: None,
         body: Some(ResponseBody::Launch),
+        error: None,
       }),
       Command::Next(_) => Ok(Response {
         request_seq: self.seq,
         success: true,
         message: None,
         body: Some(ResponseBody::Next),
+        error: None,
       }),
       Command::Pause(_) => Ok(Response {
         request_seq: self.seq,
         success: true,
         message: None,
         body: Some(ResponseBody::Pause),
+        error: None,
       }),
       Command::Restart(_) => Ok(Response {
         request_seq: self.seq,
         success: true,
         message: None,
         body: Some(ResponseBody::Next),
+        error: None,
       }),
       Command::RestartFrame(_) => Ok(Response {
         request_seq: self.seq,
         success: true,
         message: None,
         body: Some(ResponseBody::RestartFrame),
+        error: None,
       }),
       Command::ReverseContinue(_) => Ok(Response {
         request_seq: self.seq,
         success: true,
         message: None,
         body: Some(ResponseBody::ReverseContinue),
+        error: None,
       }),
       Command::StepBack(_) => Ok(Response {
         request_seq: self.seq,
         success: true,
         message: None,
         body: Some(ResponseBody::StepBack),
+        error: None,
       }),
       Command::StepIn(_) => Ok(Response {
         request_seq: self.seq,
         success: true,
         message: None,
         body: Some(ResponseBody::StepIn),
+        error: None,
       }),
       Command::StepOut(_) => Ok(Response {
         request_seq: self.seq,
         success: true,
         message: None,
         body: Some(ResponseBody::StepOut),
+        error: None,
       }),
       Command::Terminate(_) => Ok(Response {
         request_seq: self.seq,
         success: true,
         message: None,
         body: Some(ResponseBody::Terminate),
+        error: None,
       }),
       Command::TerminateThreads(_) => Ok(Response {
         request_seq: self.seq,
         success: true,
         message: None,
         body: Some(ResponseBody::TerminateThreads),
+        error: None,
       }),
       _ => Err(ServerError::ResponseConstructError),
     }

--- a/dap/src/requests.rs
+++ b/dap/src/requests.rs
@@ -51,9 +51,9 @@ pub struct InitializeArguments {
   pub adapter_id: String,
   /// The ISO-639 locale of the client using this adapter, e.g. en-US or de-CH.
   pub locale: Option<String>,
-  /// If true all line numbers are 1-based (default).
+  /// If true all line i64s are 1-based (default).
   pub lines_start_at1: Option<bool>,
-  /// If true all column numbers are 1-based (default).
+  /// If true all column i64s are 1-based (default).
   pub columns_start_at1: Option<bool>,
   /// Determines in what format paths are specified. The default is `path`, which
   /// is the native format.
@@ -74,6 +74,8 @@ pub struct InitializeArguments {
   pub supports_memory_event: Option<bool>,
   /// Client supports the `argsCanBeInterpretedByShell` attribute on the `runInTerminal` request.
   pub supports_args_can_be_interpreted_by_shell: Option<bool>,
+  /// Client supports the `startDebugging` request.
+  pub supports_start_debugging_request: Option<bool>,
 }
 
 //// Arguments for an SetBreakpoints request.

--- a/dap/src/requests.rs
+++ b/dap/src/requests.rs
@@ -233,8 +233,9 @@ pub struct ContinueArguments {
 pub struct DataBreakpointInfoArguments {
   /// Reference to the variable container if the data breakpoint is requested for
   /// a child of the container. The `variablesReference` must have been obtained
-  /// in the current suspended state. See 'Lifetime of Object References' in the
-  /// Overview section for details.
+  /// in the current suspended state.
+  /// See [Lifetime of Object References](https://microsoft.github.io/debug-adapter-protocol/overview#lifetime-of-objects-references)
+  /// in the Overview section of the specification for details.
   pub variables_reference: Option<i64>,
   /// The name of the variable's child to obtain data breakpoint information for.
   /// If `variablesReference` isn't specified, this can be an expression.
@@ -469,6 +470,8 @@ pub struct SetInstructionBreakpointsArguments {
 #[serde(rename_all(deserialize = "camelCase", serialize = "snake_case"))]
 pub struct SetVariableArguments {
   /// The reference of the variable container.
+  /// See [Lifetime of Object References](https://microsoft.github.io/debug-adapter-protocol/overview#lifetime-of-objects-references)
+  /// in the Overview section of the specification for details.
   pub variables_reference: i64,
   /// The name of the variable in the container.
   pub name: String,
@@ -581,7 +584,10 @@ pub struct TerminateThreadsArguments {
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(rename_all(deserialize = "camelCase", serialize = "snake_case"))]
 pub struct VariablesArguments {
-  /// The Variable reference.
+  /// The variable for which to retrieve its children. The `variablesReference`
+  /// must have been obtained in the current suspended state.
+  /// See [Lifetime of Object References](https://microsoft.github.io/debug-adapter-protocol/overview#lifetime-of-objects-references)
+  /// in the Overview section of the specification for details.
   pub variables_reference: i64,
   /// Filter to limit the child variables to either named or indexed. If omitted,
   /// both types are fetched.

--- a/dap/src/requests.rs
+++ b/dap/src/requests.rs
@@ -232,11 +232,17 @@ pub struct ContinueArguments {
 #[serde(rename_all(deserialize = "camelCase", serialize = "snake_case"))]
 pub struct DataBreakpointInfoArguments {
   /// Reference to the variable container if the data breakpoint is requested for
-  /// a child of the container.
+  /// a child of the container. The `variablesReference` must have been obtained
+  /// in the current suspended state. See 'Lifetime of Object References' in the
+  /// Overview section for details.
   pub variables_reference: Option<i64>,
   /// The name of the variable's child to obtain data breakpoint information for.
   /// If `variablesReference` isn't specified, this can be an expression.
   pub name: String,
+  /// When `name` is an expression, evaluate it in the scope of this stack frame.
+  /// If not specified, the expression is evaluated in the global scope. When
+  /// `variablesReference` is specified, this property has no effect.
+  pub frame_id: Option<i64>,
 }
 
 //// Arguments for a Disassemble request.

--- a/dap/src/responses.rs
+++ b/dap/src/responses.rs
@@ -52,7 +52,12 @@ pub struct ContinueResponse {
 pub struct DataBreakpointInfoResponse {
   /// An identifier for the data on which a data breakpoint can be registered
   /// with the `setDataBreakpoints` request or null if no data breakpoint is
-  /// available.
+  /// available. If a `variablesReference` or `frameId` is passed, the `dataId`
+  /// is valid in the current suspended state, otherwise it's valid
+  /// indefinitely. See 'Lifetime of Object References' in the Overview section
+  /// for details. Breakpoints set using the `dataId` in the
+  /// `setDataBreakpoints` request may outlive the lifetime of the associated
+  /// `dataId`.
   pub data_id: Option<String>,
   /// UI String that describes on what data the breakpoint is set on or why a
   /// data breakpoint is not available.

--- a/dap/src/responses.rs
+++ b/dap/src/responses.rs
@@ -263,18 +263,18 @@ pub struct SetVariableResponse {
   /// in the Overview section of the specification for details.
   #[serde(skip_serializing_if = "Option::is_none")]
   pub variables_reference: Option<i64>,
-  /// The i64 of named child variables.
+  /// The number of named child variables.
   /// The client can use this information to present the variables in a paged
   /// UI and fetch them in chunks.
   /// The value should be less than or equal to 2147483647 (2^31-1).
   #[serde(skip_serializing_if = "Option::is_none")]
-  pub named_variables: Option<i64>,
-  /// The i64 of indexed child variables.
+  pub named_variables: Option<i32>,
+  /// The number of indexed child variables.
   /// The client can use this information to present the variables in a paged
   /// UI and fetch them in chunks.
   /// The value should be less than or equal to 2147483647 (2^31-1).
   #[serde(skip_serializing_if = "Option::is_none")]
-  pub indexed_variables: Option<i64>,
+  pub indexed_variables: Option<i32>,
 }
 
 #[derive(Serialize, Debug, Default, Clone)]

--- a/dap/src/responses.rs
+++ b/dap/src/responses.rs
@@ -98,6 +98,8 @@ pub struct EvaluateResponse {
   /// children can be retrieved by passing `variablesReference` to the
   /// `variables` request.
   /// The value should be less than or equal to 2147483647 (2^31-1).
+  /// See [Lifetime of Object References](https://microsoft.github.io/debug-adapter-protocol/overview#lifetime-of-objects-references)
+  /// in the Overview section of the specification for details.
   pub variables_reference: i64,
   /// The i64 of named child variables.
   /// The client can use this information to present the variables in a paged
@@ -257,6 +259,8 @@ pub struct SetVariableResponse {
   /// children can be retrieved by passing `variablesReference` to the
   /// `variables` request.
   /// The value should be less than or equal to 2147483647 (2^31-1).
+  /// See [Lifetime of Object References](https://microsoft.github.io/debug-adapter-protocol/overview#lifetime-of-objects-references)
+  /// in the Overview section of the specification for details.
   #[serde(skip_serializing_if = "Option::is_none")]
   pub variables_reference: Option<i64>,
   /// The i64 of named child variables.
@@ -303,6 +307,8 @@ pub struct SetExpressionResponse {
   /// can be retrieved by passing `variablesReference` to the `variables`
   /// request.
   /// The value should be less than or equal to 2147483647 (2^31-1).
+  /// See [Lifetime of Object References](https://microsoft.github.io/debug-adapter-protocol/overview#lifetime-of-objects-references)
+  /// in the Overview section of the specification for details.
   #[serde(skip_serializing_if = "Option::is_none")]
   pub variables_reference: Option<i64>,
   /// The i64 of named child variables.

--- a/dap/src/responses.rs
+++ b/dap/src/responses.rs
@@ -311,18 +311,18 @@ pub struct SetExpressionResponse {
   /// in the Overview section of the specification for details.
   #[serde(skip_serializing_if = "Option::is_none")]
   pub variables_reference: Option<i64>,
-  /// The i64 of named child variables.
+  /// The number of named child variables.
   /// The client can use this information to present the variables in a paged
   /// UI and fetch them in chunks.
   /// The value should be less than or equal to 2147483647 (2^31-1).
   #[serde(skip_serializing_if = "Option::is_none")]
-  pub named_variables: Option<i64>,
-  /// The i64 of indexed child variables.
+  pub named_variables: Option<i32>,
+  /// The number of indexed child variables.
   /// The client can use this information to present the variables in a paged
   /// UI and fetch them in chunks.
   /// The value should be less than or equal to 2147483647 (2^31-1).
   #[serde(skip_serializing_if = "Option::is_none")]
-  pub indexed_variables: Option<i64>,
+  pub indexed_variables: Option<i32>,
 }
 
 #[derive(Serialize, Debug, Default, Clone)]

--- a/dap/src/responses.rs
+++ b/dap/src/responses.rs
@@ -4,8 +4,8 @@ use serde::Serialize;
 
 use crate::types::{
   Breakpoint, BreakpointLocation, Capabilities, CompletionItem, DataBreakpointAccessType,
-  DisassembledInstruction, ExceptionBreakMode, ExceptionDetails, GotoTarget, Module, Scope, Source,
-  StackFrame, Thread, Variable, VariablePresentationHint,
+  DisassembledInstruction, ExceptionBreakMode, ExceptionDetails, GotoTarget, Message, Module,
+  Scope, Source, StackFrame, Thread, Variable, VariablePresentationHint,
 };
 
 /// Represents a response message that is either a cancellation or a short error string.
@@ -628,6 +628,8 @@ pub struct Response {
   /// false.
   #[serde(flatten, skip_serializing_if = "Option::is_none")]
   pub body: Option<ResponseBody>,
+  /// A structured error message.
+  pub error: Option<Message>,
 }
 
 #[cfg(test)]
@@ -641,6 +643,7 @@ mod test {
       success: false,
       message: Some(ResponseMessage::Error("test".to_string())),
       body: None,
+      error: None,
     };
     let val = serde_json::to_value(a).unwrap();
 
@@ -653,6 +656,7 @@ mod test {
       success: false,
       message: Some(ResponseMessage::Cancelled),
       body: None,
+      error: None,
     };
     let val = serde_json::to_value(a).unwrap();
     assert!(val.get("message").unwrap().is_string());
@@ -663,6 +667,7 @@ mod test {
       success: false,
       message: Some(ResponseMessage::NotStopped),
       body: None,
+      error: None,
     };
     let val = serde_json::to_value(a).unwrap();
     assert!(val.get("message").unwrap().is_string());

--- a/dap/src/types.rs
+++ b/dap/src/types.rs
@@ -1768,7 +1768,9 @@ pub struct Scope {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub presentation_hint: Option<ScopePresentationhint>,
   /// The variables of this scope can be retrieved by passing the value of
-  /// `variablesReference` to the `variables` request.
+  /// `variablesReference` to the `variables` request as long as execution
+  /// remains suspended. See [Lifetime of Object References](https://microsoft.github.io/debug-adapter-protocol/overview#lifetime-of-objects-references)
+  /// in the Overview section of the specification for details.
   pub variables_reference: i64,
   /// The i64 of named variables in this scope.
   /// The client can use this information to present the variables in a paged UI
@@ -1982,8 +1984,9 @@ pub struct Variable {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub evaluate_name: Option<String>,
   /// If `variablesReference` is > 0, the variable is structured and its children
-  /// can be retrieved by passing `variablesReference` to the `variables`
-  /// request.
+  /// can be retrieved by passing `variablesReference` to the `variables` request
+  /// as long as execution remains suspended. See [Lifetime of Object References](https://microsoft.github.io/debug-adapter-protocol/overview#lifetime-of-objects-references)
+  /// in the Overview section of the specification for details.
   pub variables_reference: i64,
   /// The i64 of named child variables.
   /// The client can use this information to present the children in a paged UI

--- a/dap/src/types.rs
+++ b/dap/src/types.rs
@@ -994,9 +994,6 @@ pub struct ValueFormat {
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(rename_all(deserialize = "camelCase", serialize = "snake_case"))]
 pub struct StackFrameFormat {
-  /// Display the value in hex.
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub hex: Option<bool>,
   /// Displays parameters for the stack frame.
   #[serde(skip_serializing_if = "Option::is_none")]
   pub parameters: Option<bool>,

--- a/dap/src/types.rs
+++ b/dap/src/types.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::str::FromStr;
 
@@ -2105,3 +2106,34 @@ impl ToString for StartDebuggingRequestKind {
 
 fromstr_deser! { StartDebuggingRequestKind }
 tostr_ser! { StartDebuggingRequestKind }
+
+/// A structured message object. Used to return errors from requests.
+///
+/// Specification: [Message](https://microsoft.github.io/debug-adapter-protocol/specification#Types_Message)
+#[derive(Serialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "integration_testing", derive(Dummy))]
+pub struct Message {
+  /// Unique (within a debug adapter implementation) identifier for the message.
+  /// The purpose of these error IDs is to help extension authors that have the
+  /// requirement that every user visible error message needs a corresponding
+  /// error i64, so that users or customer support can find information about
+  /// the specific error more easily.
+  pub id: i64,
+  /// A format String for the message. Embedded variables have the form `{name}`.
+  /// If variable name starts with an underscore character, the variable does not
+  /// contain user data (PII) and can be safely used for telemetry purposes.
+  pub format: String,
+  /// An object used as a dictionary for looking up the variables in the format string.
+  pub variables: HashMap<String, String>,
+  /// An object used as a dictionary for looking up the variables in the format
+  /// String.
+  /// If true send to telemetry.
+  pub send_telemetry: Option<bool>,
+  /// If true show user.
+  pub show_user: Option<bool>,
+  /// A url where additional information about this message can be found.
+  pub url: Option<String>,
+  /// A label that is presented to the user as the UI for opening the url.
+  pub url_label: Option<String>,
+}

--- a/dap/src/types.rs
+++ b/dap/src/types.rs
@@ -130,7 +130,7 @@ pub struct Capabilities {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub supports_conditional_breakpoints: Option<bool>,
   /// The debug adapter supports breakpoints that break execution after a
-  /// specified number of hits.
+  /// specified i64 of hits.
   #[serde(skip_serializing_if = "Option::is_none")]
   pub supports_hit_conditional_breakpoints: Option<bool>,
   /// The debug adapter supports a (side effect free) `evaluate` request for data
@@ -168,7 +168,8 @@ pub struct Capabilities {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub supports_modules_request: Option<bool>,
   /// The set of additional module information exposed by the debug adapter.
-  pub additional_module_columns: Vec<ColumnDescriptor>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub additional_module_columns: Option<Vec<ColumnDescriptor>>,
   /// Checksum algorithms supported by the debug adapter.
   #[serde(skip_serializing_if = "Option::is_none")]
   pub supported_checksum_algorithms: Option<Vec<ChecksumAlgorithm>>,

--- a/dap/src/types.rs
+++ b/dap/src/types.rs
@@ -1620,14 +1620,45 @@ tostr_ser! { VariablePresentationHintVisibility }
 pub struct VariablePresentationHint {
   /// The kind of variable. Before introducing additional values, try to use the
   /// listed values.
+  /// Values:
+  /// 'property': Indicates that the object is a property.
+  /// 'method': Indicates that the object is a method.
+  /// 'class': Indicates that the object is a class.
+  /// 'data': Indicates that the object is data.
+  /// 'event': Indicates that the object is an event.
+  /// 'baseClass': Indicates that the object is a base class.
+  /// 'innerClass': Indicates that the object is an inner class.
+  /// 'interface': Indicates that the object is an interface.
+  /// 'mostDerivedClass': Indicates that the object is the most derived class.
+  /// 'virtual': Indicates that the object is virtual, that means it is a
+  /// synthetic object introduced by the adapter for rendering purposes, e.g. an
+  /// index range for large arrays.
+  /// 'dataBreakpoint': Deprecated: Indicates that a data breakpoint is
+  /// registered for the object. The `hasDataBreakpoint` attribute should
+  /// generally be used instead.
+  /// etc.
   #[serde(skip_serializing_if = "Option::is_none")]
   pub kind: Option<VariablePresentationHintKind>,
   /// Set of attributes represented as an array of Strings. Before introducing
   /// additional values, try to use the listed values.
+  /// Values:
+  /// 'static': Indicates that the object is static.
+  /// 'constant': Indicates that the object is a constant.
+  /// 'readOnly': Indicates that the object is read only.
+  /// 'rawString': Indicates that the object is a raw String.
+  /// 'hasObjectId': Indicates that the object can have an Object ID created for
+  /// it.
+  /// 'canHaveObjectId': Indicates that the object has an Object ID associated
+  /// with it.
+  /// 'hasSideEffects': Indicates that the evaluation had side effects.
+  /// 'hasDataBreakpoint': Indicates that the object has its value tracked by a
+  /// data breakpoint.
+  /// etc.
   #[serde(skip_serializing_if = "Option::is_none")]
   pub attributes: Option<Vec<VariablePresentationHintAttributes>>,
   /// Visibility of variable. Before introducing additional values, try to use
   /// the listed values.
+  /// Values: 'public', 'private', 'protected', 'internal', 'final', etc.
   #[serde(skip_serializing_if = "Option::is_none")]
   pub visibility: Option<VariablePresentationHintVisibility>,
   /// If true, clients can present the variable with a UI that supports a

--- a/dap/src/utils.rs
+++ b/dap/src/utils.rs
@@ -1,0 +1,65 @@
+use std::fmt::{Display, Formatter};
+
+/// A struct representing a version of the DAP specification.
+/// This version corresponds to the [changelog](https://microsoft.github.io/debug-adapter-protocol/changelog)
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Version {
+  /// Major version.
+  pub major: i64,
+  /// Minor version.
+  pub minor: i64,
+  /// Patch version. Historically, this is "x" in the changelog for most versions. That value
+  /// is represented as `None` here.
+  pub patch: Option<i64>,
+  /// The git commit in the DAP repo that corresponds to this version.
+  /// Please note that historically, versions (as of 1.62.x) are not tagged in the DAP repo.
+  /// Until that changes, we are using the commit that updates the JSON-schema in the gh-pages
+  /// branch.
+  pub git_commit: String,
+}
+
+impl Display for Version {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    match self.patch {
+      Some(patch) => write!(f, "{}.{}.{}", self.major, self.minor, patch),
+      None => write!(f, "{}.{}.x", self.major, self.minor),
+    }
+  }
+}
+
+/// Returns the version of the DAP specification that this crate implements.
+/// Please note that historically, the DAP changelog hasn't been super accurate and the
+/// versions (as of 1.62.x) are not tagged in the DAP repo. Until that changes, we are
+/// using the commit that adds the last changelog entry for a given version.
+pub fn get_spec_version() -> Version {
+  Version {
+    major: 1,
+    minor: 62,
+    patch: None,
+    git_commit: "7f284b169ecd19602487eb4d290ae651d4398ce7".to_string(),
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[test]
+  fn test_version_display() {
+    let version = Version {
+      major: 1,
+      minor: 62,
+      patch: None,
+      git_commit: "7f284b169ecd19602487eb4d290ae651d4398ce7".to_string(),
+    };
+    assert_eq!(version.to_string(), "1.62.x");
+
+    let version = Version {
+      major: 1,
+      minor: 62,
+      patch: Some(1),
+      git_commit: "7f284b169ecd19602487eb4d290ae651d4398ce7".to_string(),
+    };
+    assert_eq!(version.to_string(), "1.62.1");
+  }
+}

--- a/dap/src/utils.rs
+++ b/dap/src/utils.rs
@@ -28,9 +28,10 @@ impl Display for Version {
 }
 
 /// Returns the version of the DAP specification that this crate implements.
+///
 /// Please note that historically, the DAP changelog hasn't been super accurate and the
 /// versions (as of 1.62.x) are not tagged in the DAP repo. Until that changes, we are
-/// using the commit that adds the last changelog entry for a given version.
+/// using the commit that *adds the corresponding JSON-schema in the **gh-pages** branch*.
 pub fn get_spec_version() -> Version {
   Version {
     major: 1,

--- a/integration_tests/7f284b169ecd19602487eb4d290ae651d4398ce7_debugAdapterProtocol.json
+++ b/integration_tests/7f284b169ecd19602487eb4d290ae651d4398ce7_debugAdapterProtocol.json
@@ -1414,7 +1414,7 @@
 		"SetExceptionBreakpointsResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to `setExceptionBreakpoints` request.\nThe response contains an array of `Breakpoint` objects with information about each exception breakpoint or filter. The `Breakpoint` objects are in the same order as the elements of the `filters`, `filterOptions`, `exceptionOptions` arrays given as arguments. If both `filters` and `filterOptions` are given, the returned array must start with `filters` information first, followed by `filterOptions` information.\nThe `verified` property of a `Breakpoint` object signals whether the exception breakpoint or filter could be successfully created and whether the condition or hit count expressions are valid. In case of an error the `message` property explains the problem. The `id` property can be used to introduce a unique ID for the exception breakpoint or filter so that it can be updated subsequently by sending breakpoint events.\nFor backward compatibility both the `breakpoints` array and the enclosing `body` are optional. If these elements are missing a client is not able to show problems for individual exception breakpoints or filters.",
+				"description": "Response to `setExceptionBreakpoints` request.\nThe response contains an array of `Breakpoint` objects with information about each exception breakpoint or filter. The `Breakpoint` objects are in the same order as the elements of the `filters`, `filterOptions`, `exceptionOptions` arrays given as arguments. If both `filters` and `filterOptions` are given, the returned array must start with `filters` information first, followed by `filterOptions` information.\nThe `verified` property of a `Breakpoint` object signals whether the exception breakpoint or filter could be successfully created and whether the condition is valid. In case of an error the `message` property explains the problem. The `id` property can be used to introduce a unique ID for the exception breakpoint or filter so that it can be updated subsequently by sending breakpoint events.\nFor backward compatibility both the `breakpoints` array and the enclosing `body` are optional. If these elements are missing a client is not able to show problems for individual exception breakpoints or filters.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -1477,7 +1477,7 @@
 						"properties": {
 							"dataId": {
 								"type": [ "string", "null" ],
-								"description": "An identifier for the data on which a data breakpoint can be registered with the `setDataBreakpoints` request or null if no data breakpoint is available."
+								"description": "An identifier for the data on which a data breakpoint can be registered with the `setDataBreakpoints` request or null if no data breakpoint is available. If a `variablesReference` or `frameId` is passed, the `dataId` is valid in the current suspended state, otherwise it's valid indefinitely. See 'Lifetime of Object References' in the Overview section for details. Breakpoints set using the `dataId` in the `setDataBreakpoints` request may outlive the lifetime of the associated `dataId`."
 							},
 							"description": {
 								"type": "string",

--- a/integration_tests/build.rs
+++ b/integration_tests/build.rs
@@ -27,14 +27,17 @@ fn main() -> DynResult<()> {
   let ast = parse_file(&dap_src.join("responses.rs"))?;
   let resp_to_body_ty = HashMap::from([("Initialize".to_string(), "Capabilities")]);
 
-  // These responses are skipped because the schema for Source (which they contain) is
-  // self-referential and we can't load that the way we're doing it now (by manually dereferencing
-  // the $ref's in the schema).
-  // This is something that jsonschema should explicitly develop support for.
-  let skipped_responses: HashSet<_> = ["LoadedSources", "Scopes"]
-    .iter()
-    .map(|s| s.to_string())
-    .collect();
+  let skipped_responses: HashSet<_> = [
+    // These responses are skipped because the schema for Source (which they contain) is
+    // self-referential and we can't load that the way we're doing it now (by manually dereferencing
+    // the $ref's in the schema).
+    // This is something that jsonschema should explicitly develop support for.
+    "LoadedSources",
+    "Scopes",
+  ]
+  .iter()
+  .map(|s| s.to_string())
+  .collect();
 
   for item in ast.items {
     if let syn::Item::Enum(e) = item {
@@ -77,6 +80,7 @@ fn main() -> DynResult<()> {
               success: true,
               message: None,
               body: Some(ResponseBody::#ident #init_part),
+              error: None,
             };
             let instance = resp_to_value(&resp);
             let result = compiled.validate(&instance);
@@ -133,6 +137,7 @@ fn main() -> DynResult<()> {
               success: true,
               message: None,
               body: Some(ResponseBody::#ident #init_part),
+              error: None,
             };
             let instance = resp_to_value(&resp);
             let result = compiled.validate(&instance);

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -179,7 +179,7 @@ mod integration_tests {
 
   pub fn get_schema(item: &str) -> Value {
     let schema =
-      include_str!("../b01a8da52b83850c1a35e024bca09f7b285ac109_debugAdapterProtocol.json");
+      include_str!("../7f284b169ecd19602487eb4d290ae651d4398ce7_debugAdapterProtocol.json");
     let schema: Value = serde_json::from_str(schema).unwrap();
     let mut refs = HashSet::new();
 


### PR DESCRIPTION
This PR updates the implementation to conform with v1.62.x. Until https://github.com/microsoft/debug-adapter-protocol/issues/420 is addressed in some way, I'm using the commit hash that updates the schema in the DAP repo. 

@nuid64 looks like I can't add you as a reviewer but your thoughts would be welcome as well. 

I think after this PR it's time for another alpha release. Next up, it probably makes sense to attempt @pileghoff's idea and implement a small, real-world adapter that can work with real editors.