### PR TITLE
Allow multi-threaded sends

### DIFF
--- a/dap/src/errors.rs
+++ b/dap/src/errors.rs
@@ -33,4 +33,7 @@ pub enum ServerError {
 
   #[error("Trying to construct a non-sense response (such as an ACK for a request that requires a response body")]
   ResponseConstructError,
+
+  #[error("Output lock is poisoned")]
+  OutputLockError,
 }

--- a/dap/src/lib.rs
+++ b/dap/src/lib.rs
@@ -75,6 +75,25 @@
 //!   } else {
 //!     return Err(Box::new(MyAdapterError::UnhandledCommandError));
 //!   }
+//!
+//!   // You can send events from other threads while the server is blocked
+//!   // polling for requests by grabbing a `ServerOutput` mutex:
+//!   let server_output = server.output.clone();
+//!   std::thread::spawn(move || {
+//!       std::thread::sleep(std::time::Duration::from_millis(500));
+//!
+//!       let mut server_output = server_output.lock().unwrap();
+//!       server_output
+//!           .send_event(Event::Capabilities(events::CapabilitiesEventBody {
+//!               ..Default::default()
+//!           }))
+//!           .unwrap();
+//!   });
+//!
+//!   // The thread will concurrently send an event while we are polling
+//!   // for the next request
+//!   let _ = server.poll_request()?;
+//!
 //!   Ok(())
 //! }
 //! ```

--- a/dap/src/server.rs
+++ b/dap/src/server.rs
@@ -119,7 +119,10 @@ impl<R: Read, W: Write> Server<R, W> {
   }
 
   pub fn send(&mut self, body: Sendable) -> Result<(), ServerError> {
-    let mut output = self.output.lock().unwrap();
+    let mut output = self
+      .output
+      .lock()
+      .map_err(|_| ServerError::OutputLockError)?;
     output.send(body)
   }
 

--- a/dap/src/server.rs
+++ b/dap/src/server.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 use std::io::{BufRead, BufReader, BufWriter, Read, Write};
+use std::sync::{Arc, Mutex};
 
 use serde_json;
 
@@ -26,6 +27,19 @@ enum ServerState {
 /// requests from it, as well as constructing and serializing outgoing messages.
 pub struct Server<R: Read, W: Write> {
   input_buffer: BufReader<R>,
+
+  /// A sharable `ServerOutput` object for sending messages and events from
+  /// other threads.
+  pub output: Arc<Mutex<ServerOutput<W>>>,
+}
+
+/// Handles emission of messages through the connection.
+///
+/// `ServerOutput` is responsible for sending messages to the connection.
+/// It's only accessible through a mutex that can be shared with other
+/// threads. This makes it possible to send e.g. events while the server is
+/// blocked polling requests.
+pub struct ServerOutput<W: Write> {
   output_buffer: BufWriter<W>,
   sequence_number: i64,
 }
@@ -33,10 +47,14 @@ pub struct Server<R: Read, W: Write> {
 impl<R: Read, W: Write> Server<R, W> {
   /// Construct a new Server using the given input and output streams.
   pub fn new(input: BufReader<R>, output: BufWriter<W>) -> Self {
-    Self {
-      input_buffer: input,
+    let server_output = Arc::new(Mutex::new(ServerOutput {
       output_buffer: output,
       sequence_number: 0,
+    }));
+
+    Self {
+      input_buffer: input,
+      output: server_output,
     }
   }
 
@@ -100,6 +118,25 @@ impl<R: Read, W: Write> Server<R, W> {
     }
   }
 
+  pub fn send(&mut self, body: Sendable) -> Result<(), ServerError> {
+    let mut output = self.output.lock().unwrap();
+    output.send(body)
+  }
+
+  pub fn respond(&mut self, response: Response) -> Result<(), ServerError> {
+    self.send(Sendable::Response(response))
+  }
+
+  pub fn send_event(&mut self, event: Event) -> Result<(), ServerError> {
+    self.send(Sendable::Event(event))
+  }
+
+  pub fn send_reverse_request(&mut self, request: ReverseRequest) -> Result<(), ServerError> {
+    self.send(Sendable::ReverseRequest(request))
+  }
+}
+
+impl<W: Write> ServerOutput<W> {
   pub fn send(&mut self, body: Sendable) -> Result<(), ServerError> {
     self.sequence_number += 1;
 


### PR DESCRIPTION
There is currently no way to send events to the TCP connection while the server is polling for requests. This is my attempt at making this possible:

- Pull the send methods into a separate `ServerOutput` object protected by a mutex. It is public so that users can clone it and take a lock to send messages.
- The existing send methods in `Server` take the lock and forward to `ServerOutput`. This way the changes are backward compatible.