### PR TITLE
Make tuple struct field public

### DIFF
--- a/dap/src/types.rs
+++ b/dap/src/types.rs
@@ -218,7 +218,7 @@ pub struct Capabilities {
 }
 
 #[derive(Deserialize, Serialize, Debug, Default, Clone)]
-pub struct CustomValue(Value);
+pub struct CustomValue(pub Value);
 
 #[cfg(feature = "integration_testing")]
 struct ValueFaker;


### PR DESCRIPTION
Closes #31 

So you can create instances of the tuple struct itself