### PR TITLE
Fix up missing instances of `camelCase`

### DIFF
--- a/dap/src/requests.rs
+++ b/dap/src/requests.rs
@@ -431,6 +431,7 @@ pub struct ReadMemoryArguments {
 /// Arguments for a ReadMemory request.
 #[derive(Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "client", derive(Serialize))]
+#[serde(rename_all = "camelCase")]
 pub struct RestartArguments {
   pub arguments: Option<AttachOrLaunchArguments>,
 }

--- a/dap/src/requests.rs
+++ b/dap/src/requests.rs
@@ -169,8 +169,8 @@ pub struct AttachRequestArguments {
 //// Union of Attach and Launch arguments for the Restart request.
 //// Currently the same as LaunchRequestArguments but might not be in the future.
 #[derive(Deserialize, Debug, Default, Clone)]
-#[serde(rename_all(deserialize = "camelCase", serialize = "snake_case"))]
 #[cfg_attr(feature = "client", derive(Serialize))]
+#[serde(rename_all = "camelCase")]
 pub struct AttachOrLaunchArguments {
   /// If true, the launch request should launch the program without enabling
   /// debugging.

--- a/dap/src/responses.rs
+++ b/dap/src/responses.rs
@@ -46,12 +46,14 @@ pub struct CompletionsResponse {
 }
 
 #[derive(Serialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct ContinueResponse {
   /// The value true (or a missing property) signals to the client that all
   /// threads have been resumed. The value false indicates that not all threads
   /// were resumed.
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub all_threads_continued: Option<bool>,
 }
 

--- a/dap/src/types.rs
+++ b/dap/src/types.rs
@@ -9,6 +9,7 @@ use fake::{Dummy, Fake, Faker};
 use rand::Rng;
 
 #[derive(Deserialize, Serialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct ExceptionBreakpointsFilter {
   /// The internal ID of the filter option. This value is passed to the
@@ -242,6 +243,7 @@ impl Dummy<ValueFaker> for CustomValue {
 ///
 /// Specification: [Source](https://microsoft.github.io/debug-adapter-protocol/specification#Types_Source)
 #[derive(Deserialize, Serialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct Source {
   /// The short name of the source. Every source returned from the debug adapter
@@ -286,6 +288,7 @@ pub struct Source {
 }
 
 #[derive(Deserialize, Serialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct SourceBreakpoint {
   /// The source line of the breakpoint or logpoint.
@@ -318,6 +321,7 @@ pub struct SourceBreakpoint {
 /// Information about a breakpoint created in setBreakpoints, setFunctionBreakpoints,
 /// setInstructionBreakpoints, or setDataBreakpoints requests.
 #[derive(Deserialize, Serialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct Breakpoint {
   /// The identifier for the breakpoint. It is needed if breakpoint events are
@@ -372,6 +376,7 @@ pub enum PresentationHint {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct Checksum {
   /// The algorithm used to calculate this checksum.


### PR DESCRIPTION
I noticed there were a few places where `camelCase` was missing, causing some issues with going back and forth with a Client. I've fixed those up!